### PR TITLE
Converts sample rate and scale to floats when fetching memory depth.

### DIFF
--- a/Rigol_functions.py
+++ b/Rigol_functions.py
@@ -49,7 +49,7 @@ def get_memory_depth(tn):
         scal = command(tn, "TIM:SCAL?")
 
         # mdep = h_grid * scal * srate
-        mdep = h_grid * scal * srate
+        mdep = float(h_grid) * float(scal) * float(srate)
 
     # return mdep
     return int(mdep)


### PR DESCRIPTION
The sample rate and scale can be returned in scientific notation from the scope, thus Python could not add strings and program crashed. This converts them explicitly to floats.